### PR TITLE
Fix tiled button and crash on resume/back button pressed

### DIFF
--- a/squarecamera/src/main/AndroidManifest.xml
+++ b/squarecamera/src/main/AndroidManifest.xml
@@ -3,6 +3,6 @@
     package="com.desmond.squarecamera">
 
     <application
-        android:theme="@style/AppTheme" />
+        android:theme="@style/CameraFullScreenTheme" />
 
 </manifest>

--- a/squarecamera/src/main/java/com/desmond/squarecamera/CameraActivity.java
+++ b/squarecamera/src/main/java/com/desmond/squarecamera/CameraActivity.java
@@ -45,4 +45,10 @@ public class CameraActivity extends AppCompatActivity {
     public void onCancel(View view) {
         getSupportFragmentManager().popBackStack();
     }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        finish(); // avoid stopped preview and crash after turning screen off/on
+    }
 }

--- a/squarecamera/src/main/java/com/desmond/squarecamera/CameraActivity.java
+++ b/squarecamera/src/main/java/com/desmond/squarecamera/CameraActivity.java
@@ -3,11 +3,9 @@ package com.desmond.squarecamera;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
-import android.view.WindowManager;
 
 
 public class CameraActivity extends AppCompatActivity {
@@ -16,23 +14,10 @@ public class CameraActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        setTheme(R.style.CameraFullScreenTheme);
         super.onCreate(savedInstanceState);
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        } else {
-            View decorView = getWindow().getDecorView();
-            // Hide the status bar.
-            int uiOptions = View.SYSTEM_UI_FLAG_FULLSCREEN;
-            decorView.setSystemUiVisibility(uiOptions);
-        }
-
-        if(getSupportActionBar() != null){
-            getSupportActionBar().hide();    
-        }
-        
         getWindow().setBackgroundDrawable(null);
         setContentView(R.layout.activity_camera);
 

--- a/squarecamera/src/main/res/layout/activity_camera.xml
+++ b/squarecamera/src/main/res/layout/activity_camera.xml
@@ -3,6 +3,7 @@
     android:id="@+id/fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".CameraActivity">
 
 </FrameLayout>

--- a/squarecamera/src/main/res/values-v19/styles.xml
+++ b/squarecamera/src/main/res/values-v19/styles.xml
@@ -2,7 +2,8 @@
 <resources>
     <!-- Base application theme. -->
     <style name="CameraFullScreenTheme" parent="Theme.AppCompat.NoActionBar">
-        <!-- Customize your theme here. -->
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
     </style>
 
 </resources>

--- a/squarecamera/src/main/res/values-v21/styles.xml
+++ b/squarecamera/src/main/res/values-v21/styles.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--<style name="AppTheme" parent="android:Theme.Material.Light">-->
-    <!--</style>-->
+    <style name="CameraFullScreenTheme" parent="android:Theme.Material.NoActionBar">
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/black</item>
+    </style>
 </resources>


### PR DESCRIPTION
My primary reason for these changes is to fix the tiled shutter button on larger screens like the Nexus 6 as shown in the screen shot below. I tried several things with the capture button `ImageView` before determining that programmatically hiding the status bar was causing the problem. For my purposes, showing the status bar isn't an issue and was the easiest fix.

I also noticed that if I turned the screen off, when I returned, the camera preview was stopped. When I pressed the back button, the app crashed with an error about the camera being used after `release()` was called. To fix this, I simply finish `CameraActivity` in `onPause()`. I initially tried removing and re-adding `CameraFragment`, but this caused problems with the size of the preview window after resuming.

I won't be offended if you don't want to merge these changes, but thought someone might find them useful.

![screenshot_2015-07-08-13-47-46](https://cloud.githubusercontent.com/assets/917981/8579601/2d567ca0-257b-11e5-99ec-432d226d538f.png)