### PR TITLE
allow setting the camera-facing attribute before starting the activity

### DIFF
--- a/demo/src/main/java/com/desmond/demo/MainActivity.java
+++ b/demo/src/main/java/com/desmond/demo/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Point;
+import android.hardware.Camera;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -18,6 +19,7 @@ import android.view.View;
 import android.widget.ImageView;
 
 import com.desmond.squarecamera.CameraActivity;
+import com.desmond.squarecamera.CameraFragment;
 import com.desmond.squarecamera.ImageUtility;
 
 
@@ -89,6 +91,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void launch() {
         Intent startCustomCameraIntent = new Intent(this, CameraActivity.class);
+        startCustomCameraIntent.putExtra(CameraFragment.CAMERA_ID_KEY, Camera.CameraInfo.CAMERA_FACING_FRONT);
         startActivityForResult(startCustomCameraIntent, REQUEST_CAMERA);
     }
 

--- a/squarecamera/src/main/java/com/desmond/squarecamera/CameraFragment.java
+++ b/squarecamera/src/main/java/com/desmond/squarecamera/CameraFragment.java
@@ -71,7 +71,7 @@ public class CameraFragment extends Fragment implements SurfaceHolder.Callback, 
         // in the backstack will cause improper state restoration
         // onCreate() -> onSavedInstanceState() instead of going through onCreateView()
         if (savedInstanceState == null) {
-            mCameraID = getBackCameraID();
+            mCameraID = getActivity().getIntent().getIntExtra(CAMERA_ID_KEY, getBackCameraID());
             mFlashMode = CameraSettingPreferences.getCameraFlashMode(getActivity());
             mImageParameters = new ImageParameters();
         } else {


### PR DESCRIPTION
This is useful for use-cases where you always need to use the front camera. While creating the intent set the key: CameraFragment.CAMERA_ID_KEY to Camera.CameraInfo.CAMERA_FACING_FRONT or CAMERA_FACING_BACK respectively.
It's up to you to make sure, that the front camera is available if you force using it!
